### PR TITLE
dev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
             specialArgs = {
               user = "eriim";
               hostName = "nixbox";
-              address = "192.168.2.195";
-              interface = "wlan0";
+              address = "192.168.2.3";
+              interface = "end0";
               inherit system;
             } // attrs;
             modules = [
@@ -40,10 +40,28 @@
               ./modules/rpi/4
               ./modules/samba-server
               ./modules/docker
+	      ./modules/tandoor
             ];
           }; #nixbox
 
-        nixboard =
+        nixcube =
+          let system = "aarch64-linux";
+          in nixpkgs.lib.nixosSystem {
+            specialArgs = {
+              user = "eriim";
+              hostName = "nixcube";
+              address = "192.168.2.4";
+              interface = "enu1u1";
+              inherit system;
+            } // attrs;
+            modules = [
+              ./.
+              ./modules/rpi/3
+              ./modules/docker
+            ];
+          }; #nixcube
+	
+	nixboard =
           let system = "aarch64-linux";
           in nixpkgs.lib.nixosSystem {
             specialArgs = {
@@ -62,23 +80,6 @@
               ./modules/tandoor
             ];
           }; #nixboard
-
-        nixcube =
-          let system = "aarch64-linux";
-          in nixpkgs.lib.nixosSystem {
-            specialArgs = {
-              user = "eriim";
-              hostName = "nixcube";
-              address = "192.168.2.197";
-              interface = "wlan0";
-              inherit system;
-            } // attrs;
-            modules = [
-              ./.
-              ./modules/rpi/3
-              ./modules/docker
-            ];
-          }; #nixcube
 
         terminus =
           let system = "x86_64-linux";

--- a/modules/networking/wpa/wireless.nix
+++ b/modules/networking/wpa/wireless.nix
@@ -3,9 +3,20 @@
   imports = [
     ./tailscale.nix
   ];
+
+  age.secrets."wireless.env" = {
+    file = ../../secrets/wireless.age;
+    path = "/run/secrets/wireless.env";
+  };
+
   networking = {
     inherit hostName;
     useDHCP = false;
+    wireless = {
+      enable = true;
+      environmentFile = "/run/secrets/wireless.env";
+      networks = { "@SSID@".psk = "@SSIDpass@"; };
+    };
     interfaces.${interface}.ipv4.addresses = [{
       inherit address;
       prefixLength = 24;
@@ -14,6 +25,8 @@
       address = "192.168.2.1";
       inherit interface;
     };
-    nameservers = [ "192.168.2.2" ];
+    nameservers = [ "192.168.2.24" ];
+
   };
-}
+
+}   


### PR DESCRIPTION
- Grafana
- Firewall
- Firewall
- Hostname
- Subpath
- Subpath
- .local
- .local
- tld
- Self signed
- SSL
- Nixboard
- ports
- Tandoor
- localhost for tandoor
- Backblaze backup module
- backup cleanup
- Readme
- Readme
- Auto lint/format
- Statix check
- Auto lint/format
- Russh.toml
- dns
- ether
