### PR TITLE
dev

### DIFF
--- a/disko/btrfs.nix
+++ b/disko/btrfs.nix
@@ -1,0 +1,59 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/sda"; # Adjusted to /dev/sda for VM scenario
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              priority = 1;
+              name = "ESP";
+              start = "1M";
+              end = "512M"; # Adjusted for a more standard ESP size
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "rest"; # Adjust size according to your disk layout and needs
+              content = {
+                type = "btrfs";
+                extraArgs = [ "-f" ]; # Force, ensuring it's okay to overwrite
+                subvolumes = {
+                  "/rootfs" = {
+                    mountpoint = "/";
+                  };
+                  "/home" = {
+                    mountOptions = [ "compress=zstd" ];
+                    mountpoint = "/home";
+                  };
+                  "/nix" = {
+                    mountOptions = [ "compress=zstd" "noatime" ];
+                    mountpoint = "/nix";
+                  };
+                  "/swap" = {
+                    mountpoint = "/.swapvol"; # Dedicated swap subvolume
+                  };
+                };
+
+                mountpoint = "/partition-root"; # Not typically needed as subvolumes are used
+                swap = {
+                  swapfile = {
+                    size = "2G"; # Adjusted to a more practical size
+                    path = "/.swapvol/swapfile"; # Explicitly define path within subvolume
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1703433843,
-        "narHash": "sha256-nmtA4KqFboWxxoOAA6Y1okHbZh+HsXaMPFkYHsoDRDw=",
+        "lastModified": 1712079060,
+        "narHash": "sha256-/JdiT9t+zzjChc5qQiF+jhrVhRt8figYH29rZO7pFe4=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "417caa847f9383e111d1397039c9d4337d024bf0",
+        "rev": "1381a759b205dff7a6818733118d02253340fd5e",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
             specialArgs = {
               user = "eriim";
               hostName = "nixbox";
-              address = "192.168.2.195";
-              interface = "wlan0";
+              address = "192.168.2.3";
+              interface = "end0";
               inherit system;
             } // attrs;
             modules = [
@@ -40,10 +40,28 @@
               ./modules/rpi/4
               ./modules/samba-server
               ./modules/docker
+	      ./modules/tandoor
             ];
           }; #nixbox
 
-        nixboard =
+        nixcube =
+          let system = "aarch64-linux";
+          in nixpkgs.lib.nixosSystem {
+            specialArgs = {
+              user = "eriim";
+              hostName = "nixcube";
+              address = "192.168.2.4";
+              interface = "enu1u1";
+              inherit system;
+            } // attrs;
+            modules = [
+              ./.
+              ./modules/rpi/3
+              ./modules/docker
+            ];
+          }; #nixcube
+	
+	nixboard =
           let system = "aarch64-linux";
           in nixpkgs.lib.nixosSystem {
             specialArgs = {
@@ -62,23 +80,6 @@
               ./modules/tandoor
             ];
           }; #nixboard
-
-        nixcube =
-          let system = "aarch64-linux";
-          in nixpkgs.lib.nixosSystem {
-            specialArgs = {
-              user = "eriim";
-              hostName = "nixcube";
-              address = "192.168.2.197";
-              interface = "wlan0";
-              inherit system;
-            } // attrs;
-            modules = [
-              ./.
-              ./modules/rpi/3
-              ./modules/docker
-            ];
-          }; #nixcube
 
         terminus =
           let system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
             specialArgs = {
               user = "eriim";
               hostName = "nixcube";
-              address = "192.168.2.4";
+              address = "192.168.3.4";
               interface = "enu1u1";
               inherit system;
             } // attrs;

--- a/hosts/nixboard/default.nix
+++ b/hosts/nixboard/default.nix
@@ -2,4 +2,5 @@
   imports = [
     ./hardware-configuration.nix
   ];
+
 }

--- a/hosts/nixbox/default.nix
+++ b/hosts/nixbox/default.nix
@@ -2,5 +2,5 @@
   imports = [
     ./hardware-configuration.nix
   ];
-  networking.firewall.allowedTCPPorts = [ 5006 8443 ];
+  networking.firewall.allowedTCPPorts = [ 5006 8443 2222 ];
 }

--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -11,9 +11,8 @@
       prefixLength = 24;
     }];
     defaultGateway = {
-      address = "192.168.2.1";
+      address = "192.168.3.1";
       inherit interface;
     };
-    nameservers = [ "192.168.2.2" ];
   };
 }

--- a/modules/networking/wpa/wireless.nix
+++ b/modules/networking/wpa/wireless.nix
@@ -3,9 +3,20 @@
   imports = [
     ./tailscale.nix
   ];
+
+  age.secrets."wireless.env" = {
+    file = ../../secrets/wireless.age;
+    path = "/run/secrets/wireless.env";
+  };
+
   networking = {
     inherit hostName;
     useDHCP = false;
+    wireless = {
+      enable = true;
+      environmentFile = "/run/secrets/wireless.env";
+      networks = { "@SSID@".psk = "@SSIDpass@"; };
+    };
     interfaces.${interface}.ipv4.addresses = [{
       inherit address;
       prefixLength = 24;
@@ -14,6 +25,8 @@
       address = "192.168.2.1";
       inherit interface;
     };
-    nameservers = [ "192.168.2.2" ];
+    nameservers = [ "192.168.2.24" ];
+
   };
-}
+
+}   

--- a/modules/tandoor/default.nix
+++ b/modules/tandoor/default.nix
@@ -2,8 +2,8 @@
 {
   services.tandoor-recipes = {
     enable = true;
-    port = 3002;
-    address = "127.0.0.1";
+    port = 8081;
+    address = address;
   };
-  networking.firewall.allowedTCPPorts = [ 3002 ];
+  networking.firewall.allowedTCPPorts = [ 8081 ];
 }

--- a/russh.toml
+++ b/russh.toml
@@ -2,11 +2,10 @@ servers = ["nb.toss", "nc.toss"]
 
 [ssh_options]
 "nb.toss" = "-p 2973"
-#"192.168.2.196" = "-p 2973"
 "nc.toss" = "-p 2973"
+
 [users]
 "nb.toss" = "eriim"
-#"192.168.2.196" = "eriim"
 "nc.toss" = "eriim"
 
 


### PR DESCRIPTION
- **Docker to nixcube**
- **k3s attempt**
- **kernel patches**
- **networking**
- **Gotta go to bed**
- **Docker**
- **Readme**
- **terraform**
- **Actual.yml to main.tf**
- **Removed unused secrets**
- **Docker swarm networking**
- **Sudoless nixos-rebuild**
- **Might not even need sudo**
- **No sudo maybe**
- **Sudo**
- **Updated deploy scripts**
- **Usage.md**
- **Docker swarm config**
- **Fixed docker swarm config**
- **Readme.md**
- **K3s > Docker Swarm mode**
- **K3s > Docker Swarm mode**
- **Rpi cgroups**
- **k3s networking**
- **k3s networking**
- **k3s binary only**
- **Updated deploy scripts**
- **Using shell scripts reduces prompts for 1password SSH**
- **Simplified deploy scripts**
- **Updated dep.py**
- **Concurrent dep.py**
- **Concurrent dep.py**
- **Fixed dep.py**
- **Removed shell scripts**
- **Removed shell scripts**
- **Fixed merge**
- **Fixed merge**
- **Renamed russh.json**
- **russh.toml**
- **Removed tfstate**
- **AWS Box**
- **AWS Box**
- **json**
- **nix path**
- **Removed state**
- **Workflows**
- **formatter and linting**
- **write to contents**
- **Auto lint/format**
- **Linting**
- **Flake update**
- **Soft-serve**
- **soft-serve attempt**
- **removed docker**
- **Generated readme**
- **Readme**
- **Readme**
- **Readme**
- **Readme**
- **Readme**
- **workflow**
- **python readme**
- **Auto lint/format**
- **Grafana**
- **Firewall**
- **Firewall**
- **Hostname**
- **Subpath**
- **Subpath**
- **.local**
- **.local**
- **tld**
- **Self signed**
- **SSL**
- **Nixboard**
- **ports**
- **Tandoor**
- **localhost for tandoor**
- **Backblaze backup module**
- **backup cleanup**
- **Readme**
- **Readme**
- **Auto lint/format**
- **Statix check**
- **Auto lint/format**
- **Russh.toml**
- **dns**
- **ether**
- **Auto lint/format**
- **Tandoor**
- **nc**
- **ssh**
- **btrfs**
- **Flake update**
