### PR TITLE
dev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1703433843,
-        "narHash": "sha256-nmtA4KqFboWxxoOAA6Y1okHbZh+HsXaMPFkYHsoDRDw=",
+        "lastModified": 1712079060,
+        "narHash": "sha256-/JdiT9t+zzjChc5qQiF+jhrVhRt8figYH29rZO7pFe4=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "417caa847f9383e111d1397039c9d4337d024bf0",
+        "rev": "1381a759b205dff7a6818733118d02253340fd5e",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
             specialArgs = {
               user = "eriim";
               hostName = "nixcube";
-              address = "192.168.3.4";
+              address = "192.168.2.4";
               interface = "enu1u1";
               inherit system;
             } // attrs;
@@ -67,7 +67,7 @@
             specialArgs = {
               user = "eriim";
               hostName = "nixboard";
-              address = "192.168.2.196";
+              address = "192.168.2.7";
               interface = "wlan0";
               inherit system;
             } // attrs;


### PR DESCRIPTION
- **Docker to nixcube**
- **k3s attempt**
- **kernel patches**
- **networking**
- **Gotta go to bed**
- **Docker**
- **Readme**
- **terraform**
- **Actual.yml to main.tf**
- **Removed unused secrets**
- **Docker swarm networking**
- **Sudoless nixos-rebuild**
- **Might not even need sudo**
- **No sudo maybe**
- **Sudo**
- **Updated deploy scripts**
- **Usage.md**
- **Docker swarm config**
- **Fixed docker swarm config**
- **Readme.md**
- **K3s > Docker Swarm mode**
- **K3s > Docker Swarm mode**
- **Rpi cgroups**
- **k3s networking**
- **k3s networking**
- **k3s binary only**
- **Updated deploy scripts**
- **Using shell scripts reduces prompts for 1password SSH**
- **Simplified deploy scripts**
- **Updated dep.py**
- **Concurrent dep.py**
- **Concurrent dep.py**
- **Fixed dep.py**
- **Removed shell scripts**
- **Removed shell scripts**
- **Fixed merge**
- **Fixed merge**
- **Renamed russh.json**
- **russh.toml**
- **Removed tfstate**
- **AWS Box**
- **AWS Box**
- **json**
- **nix path**
- **Removed state**
- **Workflows**
- **formatter and linting**
- **write to contents**
- **Auto lint/format**
- **Linting**
- **Flake update**
- **Soft-serve**
- **soft-serve attempt**
- **removed docker**
- **Generated readme**
- **Readme**
- **Readme**
- **Readme**
- **Readme**
- **Readme**
- **workflow**
- **python readme**
- **Auto lint/format**
- **Grafana**
- **Firewall**
- **Firewall**
- **Hostname**
- **Subpath**
- **Subpath**
- **.local**
- **.local**
- **tld**
- **Self signed**
- **SSL**
- **Nixboard**
- **ports**
- **Tandoor**
- **localhost for tandoor**
- **Backblaze backup module**
- **backup cleanup**
- **Readme**
- **Readme**
- **Auto lint/format**
- **Statix check**
- **Auto lint/format**
- **Russh.toml**
- **dns**
- **ether**
- **Auto lint/format**
- **Tandoor**
- **nc**
- **ssh**
- **Flake update**
- **Auto lint/format**
- **btrfs**
- **Flake update**
- **Auto lint/format**
- **nixcube interface**
